### PR TITLE
Fix typos in README and sensor log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mint Mobile - Home Assistant Integration
 
 
-This integration creates a sensor for each line and displays the remaining data usage for the month. If you have a Mint Mobile family, it will also pull in the data usage for each line. The sensor name is includes additional attributes about the line.
+This integration creates a sensor for each line and displays the remaining data usage for the month. If you have a Mint Mobile family, it will also pull in the data usage for each line. The sensor name includes additional attributes about the line.
 
 
 ### Attributes Included:

--- a/custom_components/mintmobile/sensor.py
+++ b/custom_components/mintmobile/sensor.py
@@ -124,7 +124,7 @@ class MintMobileSensor(Entity):
                 self.line_name = self.data["line_name"]
                 self.last_updated = self.update_time()
             else:
-                _LOGGER.error("Unable to update line data useage")
+                _LOGGER.error("Unable to update line data usage")
         else:
             _LOGGER.error("Invalid Credentials")
 
@@ -214,7 +214,7 @@ class DataUsed(Entity):
                 self.line_name = self.data["line_name"]
                 self.last_updated = self.update_time()
             else:
-                _LOGGER.error("Unable to update line data useage")
+                _LOGGER.error("Unable to update line data usage")
         else:
             _LOGGER.error("Invalid Credentials")
 


### PR DESCRIPTION
## Summary
- fix grammar in README description
- fix typo in `sensor.py` log messages

## Testing
- `python3 -m script.hassfest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68824368b90c8325983e586c277aace5