### PR TITLE
Add AGENTS guidelines for HACS integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repository Guidance for Contributors
+
+This repository contains a Home Assistant custom integration that is published through HACS. Any future automated or manual changes should follow these guidelines.
+
+## HACS Requirements
+- The repository must hold only one integration. All source code must live under `custom_components/mintmobile/`.
+- Only files needed for the integration should exist inside that folder. Do not add files from other integrations.
+- `manifest.json` inside the integration folder **must** define the following keys:
+  - `domain`
+  - `documentation`
+  - `issue_tracker`
+  - `codeowners`
+  - `name`
+  - `version`
+- Ensure `hacs.json` exists at the repository root. This file defines the HACS metadata for this integration.
+- If you publish GitHub releases they will be shown in HACS, otherwise the default branch is used.
+- For visual assets you should submit them to the [`home-assistant/brands`](https://github.com/home-assistant/brands) repository.
+
+These requirements are based on the [HACS integration publishing docs](https://www.hacs.xyz/docs/publish/integration/).
+
+## General Development Tips
+- Keep consistent Python style when modifying `custom_components/mintmobile`.
+- Documentation updates should be reflected in `README.md` when applicable.
+


### PR DESCRIPTION
## Summary
- document repo guidance for HACS-based integration in new `AGENTS.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688247431c048325b42cfc3e7e7adf40