### PR TITLE
chore: remove unused CONNECTION_CLASS assignment in config flow

### DIFF
--- a/custom_components/mintmobile/config_flow.py
+++ b/custom_components/mintmobile/config_flow.py
@@ -28,7 +28,6 @@ class MintMobileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Mint Mobile."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
         """Initialize."""


### PR DESCRIPTION
## Summary
- Removes `CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL` from `MintMobileFlowHandler` in `config_flow.py`.
- The `CONN_CLASS_*` constants have been unused by Home Assistant core since 2021.6.0 and are retained in `homeassistant/config_entries.py` only for backward compatibility with custom integrations — setting this attribute is a no-op today. Connection type is already correctly declared via `"iot_class": "cloud_polling"` in `manifest.json`.

Reference: [Config flow docs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler) and `home-assistant/core` source, which marks `CONN_CLASS_*` as "Deprecated: ... These aren't used anymore since 2021.6.0. Mainly here not to break custom integrations."

## Other findings (not changed, noted for the owner)
- `self.config_entry` manual assignment in `OptionsFlow` (deprecated, breaks in HA 2025.12) — **not present** here; `OptionsFlowHandler.__init__` already doesn't set it manually, so no change needed.
- `manifest.json` omits `integration_type`. HA docs say it's required for *core* integrations with a config flow and defaults to `"hub"` for custom integrations when omitted — docs are ambiguous on whether custom integrations must set it explicitly, so I did not guess a value. Worth setting explicitly (likely `"hub"`) if the owner wants to be future-proof.
- `manifest.json` version is `2.0.0` but the latest git tag is `v3.0` — looks like the manifest version wasn't bumped for the last release. Not a spec-compliance issue, just flagging the mismatch.

## Test plan
- [x] `python3 -m py_compile custom_components/mintmobile/*.py` passes
- [ ] Owner to confirm no regressions in config/options flow UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)