### PR TITLE
ci: add automated release workflows (bump manifest + tag + release)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,57 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, semver without 'v' prefix (e.g. 3.1.0)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be in X.Y.Z format (e.g. 3.1.0), got: ${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fail if tag already exists
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/v${{ inputs.version }}$"; then
+            echo "::error::Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Bump manifest.json version
+        run: |
+          sed -i 's/"version": *"[^"]*"/"version": "${{ inputs.version }}"/' custom_components/mintmobile/manifest.json
+          grep '"version"' custom_components/mintmobile/manifest.json
+
+      - name: Sanity check
+        run: python3 -m py_compile custom_components/mintmobile/*.py
+
+      - name: Open version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="release/v${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "chore: bump manifest version to ${{ inputs.version }}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "Release v${{ inputs.version }}" \
+            --body "Bumps \`manifest.json\` version to \`${{ inputs.version }}\`. Merging this to \`master\` will automatically tag \`v${{ inputs.version }}\` and publish a matching GitHub Release." \
+            --base master \
+            --head "$BRANCH"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,53 @@
+name: Publish release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - custom_components/mintmobile/manifest.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read manifest version
+        id: manifest
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('custom_components/mintmobile/manifest.json'))['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.manifest.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.manifest.outputs.version }}"
+          git push origin "v${{ steps.manifest.outputs.version }}"
+
+      - name: Create GitHub release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.manifest.outputs.version }}" \
+            --title "v${{ steps.manifest.outputs.version }}" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
## Why
`manifest.json` version had drifted from the actual release tag (manifest said `2.0.0`, latest published release is `v3.0`). HACS uses the manifest `version` field to report installed/available versions, so keeping it in sync with the release tag matters for update detection.

`master` requires an approving PR review, so a single workflow can't just push a version bump directly — it's split into two that hand off to each other:

## What this adds

**`release-prepare.yml`** (manual trigger, `workflow_dispatch` with a `version` input):
- Validates the version is `X.Y.Z`
- Bumps `custom_components/mintmobile/manifest.json`
- Runs `py_compile` as a sanity check
- Opens a PR (`release/vX.Y.Z` → `master`) for review

**`release-publish.yml`** (runs automatically on push to `master` when `manifest.json` changes — i.e. once the PR above is merged):
- Reads the version straight out of `manifest.json`
- Creates git tag `vX.Y.Z` and a GitHub Release with generated notes, skipping if that tag already exists

## How to cut a release going forward
1. Actions tab → "Prepare release" → Run workflow → enter e.g. `3.1.0`
2. Review/merge the PR it opens
3. "Publish release" fires automatically and creates the tag + GitHub Release — manifest and release will always match

## Test plan
- [x] Both workflow files parse as valid YAML
- [ ] Owner to do a dry run via Actions tab once merged (e.g. bump to `3.0.1` or the next real version) to confirm end-to-end behavior, since this can't be tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)