### PR TITLE
manifest: bump version to 3.0.0 to match latest release

### DIFF
--- a/custom_components/mintmobile/manifest.json
+++ b/custom_components/mintmobile/manifest.json
@@ -6,6 +6,6 @@
   "requirements": [],
   "config_flow": true,
   "issue_tracker": "https://github.com/ryanmac8/HA-Mint-Mobile/issues",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
## Summary
- `manifest.json` still said `2.0.0` after the `v3.0` release shipped. HACS reads this field to report installed/available versions, so it needs to track the actual release tag.

## Test plan
- [x] `python3 -m py_compile custom_components/mintmobile/*.py` passes
- [x] `manifest.json` parses as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)