### PR TITLE
ci: enforce Conventional Commit PR titles

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,45 @@
+name: Semantic PR
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title-lint:
+    name: title-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint PR title against Conventional Commits
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # release-please reads the squash-merge commit subject, which this
+          # repo sets to the PR title (squash-only merges, see repo settings).
+          # A non-conventional title means the change is silently invisible
+          # to release-please: no version bump, no changelog line.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            ci
+            test
+            chore
+            build
+            style
+            revert
+          requireScope: false
+          # Squash-only merges (see repo settings) default the merge UI to a
+          # single-commit PR's own commit message rather than its title. If
+          # that gets accepted at merge time, a good PR title never reaches
+          # the squash subject that release-please actually reads.
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The PR title's subject (after "type:") should not start with an uppercase letter.


### PR DESCRIPTION
## Why

This repo now merges squash-only, with the squash subject set to the PR title. release-please reads that subject to decide whether a change is releasable and which changelog section it lands in.

A PR with a non-conventional title is invisible to release-please — no version bump, no changelog entry, even for a real user-facing fix. That's exactly what happened with #40: title was `Fix 401 on usage fetch for data-only (tablet/internet) lines`, no `fix:` prefix, so it merged silently with no changelog line and 3.0.1 shipped without it being mentioned (backfilled separately via an empty commit on master).

## What

`.github/workflows/semantic-pr.yml` lints the PR title against Conventional Commits on open/edit/reopen/sync, using the same type list release-please's config recognizes (`feat`, `fix`, `perf`, `refactor`, `docs`, `ci`, `test`, `chore`, `build`, `style`, `revert`).

Also enables `validateSingleCommit` / `validateSingleCommitMatchesPrTitle`: for a single-commit PR, GitHub's squash-merge UI defaults to suggesting that commit's own message instead of the PR title. If that gets accepted at merge time, a good PR title never reaches the subject release-please actually reads.

## Next step (yours, not in this PR)

Once this is green once, add `title-lint` to the master branch's required status checks alongside `e2e`. I can't write branch protection from here — same permission block as before.