### PR TITLE
feat: support linked Minternet lines and split attribute-sensor setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This integration creates sensors for each line and displays the remaining and us
 
 Data-only lines (tablet and mobile internet plans) are supported alongside phone lines; the correct subscriber type is detected automatically on the first refresh.
 
+If your account also has a linked **Minternet** (home internet) product, it gets its own sensor pair automatically, whether you log in with your Mint Mobile phone number or your Minternet username -- either credential surfaces every product linked to the account. Each line's `line_type` attribute reads `phone`, `internet`, or `tablet` so you can tell them apart.
+
 > **WARNING: Running Multiple Clients (Token Invalidation)**
 >
 > Mint Mobile's API rotates refresh tokens and only allows one active session per account. Running another automated client (like the TypeScript MQTT bridge) or logging into the official mobile app will invalidate the integration's token.
@@ -19,21 +21,29 @@ Data-only lines (tablet and mobile internet plans) are supported alongside phone
 - Days remaining for plan (The number of days left that you have purchased)
 - Phone number
 - Line name
+- Line type (`phone`, `internet`, or `tablet`)
 - Last updated
+
+### Setup
+
+Adding the integration walks through a few short screens:
+
+1. **Account Type** -- choose Mint Mobile (phone) or Minternet. This only
+   controls how your credential is sent; if your account has both linked,
+   both still show up as separate sensors regardless of which you pick here.
+2. **Credentials** -- your phone number or Minternet username, and password.
+3. **Additional Sensors** -- each attribute above already appears on the
+   main data-usage sensor. Turn on any of the three checkboxes here only if
+   you also want that attribute as its own separate sensor entity.
+4. **Polling Interval** -- see below.
+
+All of these can be changed later from the integration's **Configure** menu.
 
 ### Polling Interval
 
 During setup you can specify how often the integration checks Mint Mobile for
 new data. The value is in **hours** and defaults to **12**. Values less than 1
 hour are not allowed.
-
-### Attributes As Additional Sensors
-
-If you want to have the following attributes as additional sensors, during the setup process or under the integration options menu check 'Display Attributes As Additional Sensors'.
-
-- Number of months purchased for plan
-- Days remaining in month (The number of days left in the data plan month)
-- Days remaining for plan (The number of days left that you have purchased)
 
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)

--- a/custom_components/mintmobile/__init__.py
+++ b/custom_components/mintmobile/__init__.py
@@ -14,13 +14,16 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import MintMobile
 from .const import (
+    ATTRIBUTE_SENSOR_KEYS,
     CONF_ATTRIBUTESENSORS,
+    CONF_LOGIN_MODE,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_POLLING_INTERVAL,
     CONF_TOKEN,
     CONF_REFRESH_TOKEN,
     CONF_EXPIRES_AT,
+    DEFAULT_LOGIN_MODE,
     DEFAULT_POLLING_INTERVAL,
     DOMAIN,
     ISSUE_URL,
@@ -28,6 +31,17 @@ from .const import (
     STARTUP_MESSAGE,
     VERSION,
 )
+
+
+def _attribute_sensor_snapshot(entry_data: dict) -> dict:
+    """Per-attribute sensor flags, falling back to any legacy blanket value.
+
+    Used to detect user-initiated option changes; must agree with the same
+    fallback sensor.py uses so a reload doesn't fire on every restart for
+    entries that predate the per-attribute keys.
+    """
+    legacy_default = bool(entry_data.get(CONF_ATTRIBUTESENSORS, False))
+    return {key: bool(entry_data.get(key, legacy_default)) for key in ATTRIBUTE_SENSOR_KEYS}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,6 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
+    login_mode = entry.data.get(CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE)
     token = entry.data.get(CONF_TOKEN)
     refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
     expires_at = entry.data.get(CONF_EXPIRES_AT)
@@ -90,6 +105,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         session=session,
         username=username,
         password=password,
+        login_mode=login_mode,
         token=token,
         refresh_token=refresh_token,
         expires_at=expires_at,
@@ -108,8 +124,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     coordinator.config_version = {
         CONF_USERNAME: username,
         CONF_PASSWORD: password,
+        CONF_LOGIN_MODE: login_mode,
         CONF_POLLING_INTERVAL: polling_interval,
-        CONF_ATTRIBUTESENSORS: entry.data.get(CONF_ATTRIBUTESENSORS),
+        **_attribute_sensor_snapshot(entry.data),
     }
 
     hass.data.setdefault(DOMAIN, {})
@@ -138,8 +155,9 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     new_config = {
         CONF_USERNAME: entry.data.get(CONF_USERNAME),
         CONF_PASSWORD: entry.data.get(CONF_PASSWORD),
+        CONF_LOGIN_MODE: entry.data.get(CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE),
         CONF_POLLING_INTERVAL: entry.data.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL),
-        CONF_ATTRIBUTESENSORS: entry.data.get(CONF_ATTRIBUTESENSORS),
+        **_attribute_sensor_snapshot(entry.data),
     }
 
     if getattr(coordinator, "config_version", None) != new_config:

--- a/custom_components/mintmobile/api.py
+++ b/custom_components/mintmobile/api.py
@@ -6,6 +6,11 @@ import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
 
+# Mirrors const.LOGIN_MODE_INTERNET/const.LOGIN_MODE_PHONE. Kept as a literal
+# here rather than imported so this module still runs standalone via test.py
+# (`from api import MintMobile`, outside the custom_components package).
+LOGIN_MODE_INTERNET = "internet"
+
 STATIC_APP_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MDc3NjY4MjQsIm5iZiI6MTUwNzc2NjgyNCwiZXhwIjoxNTk0MDgwNDI0LCJhdWQiOiJNaW50QXBwIiwiaXNzIjoiVUxUUkEifQ.r909IZmcavEhqvZO0td_-Ts_q27BBk4cCbFRXpDBQUM"
 
 # JWT segments use the base64url alphabet, which swaps "+" and "/" for "-"
@@ -39,11 +44,52 @@ def decode_jwt(token: str) -> dict:
 # 401 and must send their own type instead.
 SUBSCRIBER_TYPES = ("PHONE", "TABLET", "INTERNET")
 
+# account/{id} and its usage response both return every product linked to
+# the account in one payload: values at the top level, plus the same shape
+# again nested under "phone"/"internet"/"tablet" keys for whichever of those
+# are also linked. LINE_TYPE maps a nested key to the label exposed on that
+# line's "line_type" attribute; the top-level line uses whichever of these
+# matches its own subscriber type (see _line_type_for below).
+LINE_TYPES = ("phone", "internet", "tablet")
+
+
+def _extract_product_fields(product: dict, fallback_name: str) -> dict:
+    """Pull the common account fields out of one product's dict.
+
+    Mint returns this exact shape (msisdn, firstName, plan.{exp,endOfCycle,
+    months}) both at the top level of the account response and again nested
+    under "internet"/"tablet" for any other product linked to the account,
+    so this same extraction applies whichever dict it's handed.
+    """
+    plan = product.get("plan") or {}
+    now_sec = int(time.time())
+    plan_exp = plan.get("exp") or 0
+    end_of_cycle = plan.get("endOfCycle") or 0
+    return {
+        "phone_number": product.get("msisdn") or "",
+        "line_name": product.get("firstName") or fallback_name,
+        "endOfCycle": max(0, int((end_of_cycle - now_sec) / 86400)),
+        "months": plan.get("months") or 0,
+        "exp": max(0, int((plan_exp - now_sec) / 86400)),
+    }
+
+
+def _extract_usage_fields(usage: dict) -> dict:
+    """Pull remaining/used data out of one product's usage dict."""
+    remaining_mb = usage.get("remainingHighSpeedData", 0)
+    used_mb = usage.get("usageHighSpeedData", 0)
+    return {
+        "remaining4G": round(remaining_mb / 1024, 2),
+        "used4G": round(used_mb / 1024, 2),
+    }
+
+
 class MintMobile:
-    def __init__(self, session: aiohttp.ClientSession, username, password, token=None, refresh_token=None, expires_at=None, token_update_callback=None):
+    def __init__(self, session: aiohttp.ClientSession, username, password, login_mode="phone", token=None, refresh_token=None, expires_at=None, token_update_callback=None):
         self.session = session
         self.username = username
         self.password = password
+        self.login_mode = login_mode
         self.token = token
         self.refresh_token = refresh_token
         self.expires_at = expires_at
@@ -51,17 +97,32 @@ class MintMobile:
         self.id = ""
         self.info = {}
         self.subscriber_type = None
+        # What the account's own top-level identity is, e.g. "INTERNET" for
+        # a Minternet-only login. Learned from the login/refresh response
+        # when present (see #39); otherwise inferred from subscriber_type
+        # once usage succeeds, defaulting to PHONE as a last resort so every
+        # account that predates this attribute keeps behaving exactly as
+        # before.
+        self.primary_type = None
 
     async def async_login(self):
         """Log in to Mint Mobile and obtain a new session token."""
-        _LOGGER.debug("Logging into Mint Mobile with phone: %s", self.username)
+        _LOGGER.debug("Logging into Mint Mobile with login_mode=%s", self.login_mode)
         login_url = "https://mint-gateway.mintmobile.com/v1/mint/login"
+        # A Minternet-only credential authenticates on the same endpoint but
+        # under a "username" field instead of "msisdn". subscriberType stays
+        # "PHONE" in the request body either way -- confirmed against a real
+        # Minternet login capture (ha-mint-mobile#39); the request value
+        # doesn't reflect the account type, only the response does (read
+        # below). Don't be tempted to set it to "INTERNET" here: that's
+        # unverified and the "PHONE" constant is the only shape known to work.
+        credential_field = "username" if self.login_mode == LOGIN_MODE_INTERNET else "msisdn"
         login_body = {
-            "msisdn": self.username,
+            credential_field: self.username,
             "password": self.password,
             "subscriberType": "PHONE",
         }
-        
+
         headers = {
             "accept": "application/json",
             "content-type": "application/json",
@@ -87,7 +148,12 @@ class MintMobile:
             payload = decode_jwt(self.token)
             self.id = str(payload.get("sub") or payload.get("userId") or response.get("userId"))
             self.expires_at = payload.get("exp") or (int(time.time()) + 900)
-            
+            # Unlike the request, the login response's subscriberType does
+            # reflect the account actually authenticated -- "INTERNET" for a
+            # Minternet login, confirmed in #39. Used later to label the
+            # primary line instead of assuming it's always a phone line.
+            self.primary_type = response.get("subscriberType") or self.primary_type
+
             if self.token_update_callback:
                 self.token_update_callback(self.token, self.refresh_token, self.expires_at)
             
@@ -128,7 +194,8 @@ class MintMobile:
                     self.refresh_token = new_refresh_token
                     payload = decode_jwt(self.token)
                     self.expires_at = payload.get("exp") or (int(time.time()) + 900)
-                    
+                    self.primary_type = response.get("subscriberType") or self.primary_type
+
                     if self.token_update_callback:
                         self.token_update_callback(self.token, self.refresh_token, self.expires_at)
                     
@@ -207,8 +274,13 @@ class MintMobile:
         usage_data = None
         last_status = None
         for subscriber_type in candidates:
+            # A live capture of a real Minternet session (#39) sent "roaming"
+            # alongside "data" only for subscriberType=INTERNET; phone/tablet
+            # usage is only confirmed with "data" alone, so that's kept as-is
+            # rather than sent everywhere on an unverified guess.
+            types = ["data", "roaming"] if subscriber_type == "INTERNET" else ["data"]
             usage_body = {
-                "types": ["data"],
+                "types": types,
                 "subscriberType": subscriber_type,
             }
             async with self.session.post(usage_url, json=usage_body, headers=usage_headers) as r:
@@ -228,35 +300,45 @@ class MintMobile:
         if usage_data is None:
             raise Exception(f"Failed to fetch usage: {last_status}")
 
-        # Extract primary line info
-        phone = account_data.get("msisdn") or account_data.get("phone", {}).get("msisdn") or self.username
-        
-        plan_exp = account_data.get("plan", {}).get("exp") or account_data.get("phone", {}).get("plan", {}).get("exp") or 0
-        end_of_cycle = account_data.get("plan", {}).get("endOfCycle") or account_data.get("phone", {}).get("plan", {}).get("endOfCycle") or 0
-        plan_months = account_data.get("plan", {}).get("months") or account_data.get("phone", {}).get("plan", {}).get("months") or 0
-        line_name = account_data.get("firstName") or account_data.get("phone", {}).get("firstName") or "Mint Line"
+        # What the account's own top-level identity actually is. The login
+        # response is the most direct signal (see async_login); if that
+        # wasn't available -- e.g. resuming from a cached token -- fall back
+        # to whichever subscriber type usage just proved works, and only
+        # default to PHONE if neither is known. That default preserves exact
+        # prior behavior for every account that predates this attribute.
+        primary_type = (self.primary_type or self.subscriber_type or "PHONE").upper()
+        primary_line_type = primary_type.lower() if primary_type.lower() in LINE_TYPES else "phone"
 
-        # Calculate remaining days
-        now_sec = int(time.time())
-        days_remaining_month = max(0, int((end_of_cycle - now_sec) / 86400))
-        days_remaining_plan = max(0, int((plan_exp - now_sec) / 86400))
+        # account/{id} and its usage response both carry every linked
+        # product: values at the top level (whichever the primary identity
+        # is), plus the same shape again nested under "phone"/"internet"/
+        # "tablet" for any other product linked to the account (see #39).
+        # The top-level line is built from the top level; every other
+        # linked product becomes its own additional line below.
+        primary_product = account_data
+        if not primary_product.get("msisdn") and not primary_product.get("plan"):
+            # Some account payloads put the primary line's own fields only
+            # under this same product-type key rather than at the account's
+            # top level; fall back to that instead of reporting empty data.
+            primary_product = account_data.get(primary_line_type) or account_data
+        fields = _extract_product_fields(primary_product, fallback_name="Mint Line")
+        usage_fields = _extract_usage_fields(usage_data)
+        self.info[self.id] = {**fields, **usage_fields, "line_type": primary_line_type}
 
-        # Data calculations (MB to GB)
-        remaining_mb = usage_data.get("remainingHighSpeedData", 0)
-        used_mb = usage_data.get("usageHighSpeedData", 0)
-        
-        remaining_gb = round(remaining_mb / 1024, 2)
-        used_gb = round(used_mb / 1024, 2)
-
-        self.info[self.id] = {
-            "phone_number": phone,
-            "line_name": line_name,
-            "endOfCycle": days_remaining_month,
-            "months": plan_months,
-            "exp": days_remaining_plan,
-            "remaining4G": remaining_gb,
-            "used4G": used_gb,
-        }
+        for line_type in LINE_TYPES:
+            if line_type == primary_line_type:
+                continue
+            product = account_data.get(line_type)
+            if not product:
+                continue
+            product_usage = usage_data.get(line_type) or {}
+            fields = _extract_product_fields(product, fallback_name=f"Mint {line_type.title()}")
+            usage_fields = _extract_usage_fields(product_usage)
+            self.info[f"{self.id}:{line_type}"] = {
+                **fields,
+                **usage_fields,
+                "line_type": line_type,
+            }
 
         # Multi-line accounts lookup
         try:
@@ -287,6 +369,7 @@ class MintMobile:
                                     m_plan_exp = member.get("nextPlan", {}).get("renewalDate", 0)
                                     m_plan_months = member.get("currentPlan", {}).get("duration", 0)
 
+                                    now_sec = int(time.time())
                                     m_days_remaining_month = max(0, int((m_end_of_cycle - now_sec) / 86400))
                                     m_days_remaining_plan = max(0, int((m_plan_exp - now_sec) / 86400))
 
@@ -298,6 +381,7 @@ class MintMobile:
                                         "exp": m_days_remaining_plan,
                                         "remaining4G": m_remaining_gb,
                                         "used4G": m_used_gb,
+                                        "line_type": "phone",
                                     }
                         except Exception as member_err:
                             _LOGGER.warning("Error fetching multi-line member details for %s: %s", member_id, member_err)

--- a/custom_components/mintmobile/config_flow.py
+++ b/custom_components/mintmobile/config_flow.py
@@ -9,19 +9,43 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import MintMobile
 from .const import (
+    ATTRIBUTE_SENSOR_KEYS,
     CONF_ATTRIBUTESENSORS,
+    CONF_LOGIN_MODE,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_POLLING_INTERVAL,
+    CONF_SENSOR_DAYS_REMAINING_MONTH,
+    CONF_SENSOR_DAYS_REMAINING_PLAN,
+    CONF_SENSOR_PLAN_TERM,
     CONF_TOKEN,
     CONF_REFRESH_TOKEN,
     CONF_EXPIRES_AT,
+    DEFAULT_LOGIN_MODE,
     DEFAULT_POLLING_INTERVAL,
     DOMAIN,
+    LOGIN_MODE_INTERNET,
+    LOGIN_MODE_PHONE,
     PLATFORMS,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+LOGIN_MODE_LABELS = {
+    LOGIN_MODE_PHONE: "Mint Mobile (phone line)",
+    LOGIN_MODE_INTERNET: "Minternet",
+}
+
+
+def _attribute_sensor_defaults(data: dict) -> dict:
+    """Per-attribute defaults, falling back to a pre-existing blanket toggle.
+
+    Entries created before the per-attribute keys existed only stored
+    CONF_ATTRIBUTESENSORS; treat that as every key's default so upgrading
+    doesn't silently remove sensors someone already has.
+    """
+    legacy_default = bool(data.get(CONF_ATTRIBUTESENSORS, False))
+    return {key: bool(data.get(key, legacy_default)) for key in ATTRIBUTE_SENSOR_KEYS}
 
 
 class MintMobileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -34,28 +58,47 @@ class MintMobileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._data = {}
         self._errors = {}
 
-    async def async_step_user(self, user_input):
-        """Handle the initial step for credentials."""
+    async def async_step_user(self, user_input=None):
+        """Ask which kind of account is being added, before credentials."""
+        self._errors = {}
+
+        if user_input is not None:
+            self._data[CONF_LOGIN_MODE] = user_input[CONF_LOGIN_MODE]
+            return await self.async_step_credentials()
+
+        return await self._show_login_mode_form()
+
+    async def async_step_credentials(self, user_input=None):
+        """Handle the credentials step, once login mode is known."""
         self._errors = {}
 
         if user_input is not None:
             valid = await self._test_credentials(
-                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+                self._data.get(CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE),
             )
             if valid:
                 self._data.update(
                     {
                         CONF_USERNAME: user_input[CONF_USERNAME],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        CONF_ATTRIBUTESENSORS: user_input.get(
-                            CONF_ATTRIBUTESENSORS, False
-                        ),
                     }
                 )
-                return await self.async_step_polling()
+                return await self.async_step_attribute_sensors()
             self._errors["base"] = "invalid_credentials"
 
         return await self._show_config_form(user_input)
+
+    async def async_step_attribute_sensors(self, user_input=None):
+        """Pick which attributes also get their own separate sensor entity."""
+        self._errors = {}
+
+        if user_input is not None:
+            self._data.update({key: user_input.get(key, False) for key in ATTRIBUTE_SENSOR_KEYS})
+            return await self.async_step_polling()
+
+        return await self._show_attribute_sensors_form()
 
     async def async_step_polling(self, user_input=None):
         """Configure the polling interval after successful auth."""
@@ -69,19 +112,53 @@ class MintMobileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self._show_polling_form(user_input)
 
-    async def _show_config_form(self, user_input):  # pylint: disable=unused-argument
-        """Show the configuration form to edit creds."""
-        if not user_input:
-            user_input = {}
-
-        data_schema = OrderedDict()
-        data_schema[vol.Required("username", default="")] = str
-        data_schema[vol.Required("password", default="")] = str
-        data_schema[vol.Optional("attributesensors", default=False)] = bool
+    async def _show_login_mode_form(self):
+        """Show the login-mode picker, defaulting to a Mint Mobile phone line."""
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_LOGIN_MODE, default=DEFAULT_LOGIN_MODE
+                ): vol.In(LOGIN_MODE_LABELS)
+            }
+        )
 
         return self.async_show_form(
             step_id="user",
+            data_schema=data_schema,
+            errors=self._errors,
+        )
+
+    async def _show_config_form(self, user_input):  # pylint: disable=unused-argument
+        """Show the configuration form to edit creds."""
+        data_schema = OrderedDict()
+        data_schema[vol.Required("username", default="")] = str
+        data_schema[vol.Required("password", default="")] = str
+
+        login_mode = self._data.get(CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE)
+        credential_kind = (
+            "Minternet username" if login_mode == LOGIN_MODE_INTERNET else "phone number"
+        )
+
+        return self.async_show_form(
+            step_id="credentials",
             data_schema=vol.Schema(data_schema),
+            errors=self._errors,
+            description_placeholders={"credential_kind": credential_kind},
+        )
+
+    async def _show_attribute_sensors_form(self):
+        """Show one checkbox per attribute that can become its own sensor."""
+        data_schema = vol.Schema(
+            {
+                vol.Optional(CONF_SENSOR_PLAN_TERM, default=False): bool,
+                vol.Optional(CONF_SENSOR_DAYS_REMAINING_MONTH, default=False): bool,
+                vol.Optional(CONF_SENSOR_DAYS_REMAINING_PLAN, default=False): bool,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="attribute_sensors",
+            data_schema=data_schema,
             errors=self._errors,
         )
 
@@ -103,10 +180,10 @@ class MintMobileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def _test_credentials(self, username, password):
+    async def _test_credentials(self, username, password, login_mode=DEFAULT_LOGIN_MODE):
         """Return true if credentials is valid."""
         session = async_get_clientsession(self.hass)
-        mm = MintMobile(session, username, password)
+        mm = MintMobile(session, username, password, login_mode=login_mode)
         try:
             return await mm.async_login()
         except Exception:
@@ -133,16 +210,37 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self._data = user_input
             return await self._update_options()
 
-        if self.config_entry.data.get(CONF_ATTRIBUTESENSORS):
-            attributesensors = True
-        else:
-            attributesensors = False
+        attribute_defaults = _attribute_sensor_defaults(self.config_entry.data)
         data_schema = OrderedDict()
         data_schema[
             vol.Required("username", default=self.config_entry.data.get(CONF_USERNAME))
         ] = str
         data_schema[vol.Required("password", default="")] = str
-        data_schema[vol.Required("attributesensors", default=attributesensors)] = bool
+        data_schema[
+            vol.Required(
+                CONF_LOGIN_MODE,
+                default=self.config_entry.data.get(
+                    CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE
+                ),
+            )
+        ] = vol.In(LOGIN_MODE_LABELS)
+        data_schema[
+            vol.Optional(
+                CONF_SENSOR_PLAN_TERM, default=attribute_defaults[CONF_SENSOR_PLAN_TERM]
+            )
+        ] = bool
+        data_schema[
+            vol.Optional(
+                CONF_SENSOR_DAYS_REMAINING_MONTH,
+                default=attribute_defaults[CONF_SENSOR_DAYS_REMAINING_MONTH],
+            )
+        ] = bool
+        data_schema[
+            vol.Optional(
+                CONF_SENSOR_DAYS_REMAINING_PLAN,
+                default=attribute_defaults[CONF_SENSOR_DAYS_REMAINING_PLAN],
+            )
+        ] = bool
         data_schema[
             vol.Optional(
                 CONF_POLLING_INTERVAL,
@@ -163,18 +261,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         mm = await self._test_credentials(
             self._data[CONF_USERNAME],
             self._data[CONF_PASSWORD],
+            self._data.get(CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE),
         )
         if mm is not None:
             new_data = {
                 **self.config_entry.data,
                 CONF_USERNAME: self._data[CONF_USERNAME],
                 CONF_PASSWORD: self._data[CONF_PASSWORD],
-                CONF_ATTRIBUTESENSORS: self._data[CONF_ATTRIBUTESENSORS],
+                CONF_LOGIN_MODE: self._data.get(CONF_LOGIN_MODE, DEFAULT_LOGIN_MODE),
                 CONF_POLLING_INTERVAL: self._data[CONF_POLLING_INTERVAL],
                 CONF_TOKEN: mm.token,
                 CONF_REFRESH_TOKEN: mm.refresh_token,
                 CONF_EXPIRES_AT: mm.expires_at,
             }
+            for key in ATTRIBUTE_SENSOR_KEYS:
+                new_data[key] = self._data.get(key, False)
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data
             )
@@ -183,14 +284,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self._errors["base"] = "invalid_credentials"
             return await self.async_step_user()
 
-    async def _test_credentials(self, username, password):
+    async def _test_credentials(self, username, password, login_mode=DEFAULT_LOGIN_MODE):
         """Return true if credentials is valid."""
         session = async_get_clientsession(self.hass)
-        mm = MintMobile(session, username, password)
+        mm = MintMobile(session, username, password, login_mode=login_mode)
         try:
             if await mm.async_login():
                 return mm
         except Exception:
             pass
         return None
-

--- a/custom_components/mintmobile/const.py
+++ b/custom_components/mintmobile/const.py
@@ -22,15 +22,37 @@ CONF_ENABLED = "enabled"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_ATTRIBUTESENSORS = "attributesensors"
+CONF_SENSOR_PLAN_TERM = "sensor_plan_term"
+CONF_SENSOR_DAYS_REMAINING_MONTH = "sensor_days_remaining_month"
+CONF_SENSOR_DAYS_REMAINING_PLAN = "sensor_days_remaining_plan"
+# Each attribute already appears on the main data-usage sensor; these three
+# optionally split one out as its own sensor entity. Entries created before
+# this existed only have the single blanket CONF_ATTRIBUTESENSORS -- readers
+# of these keys should fall back to that value for such entries, not to
+# False, so upgrading doesn't silently remove sensors someone already has.
+ATTRIBUTE_SENSOR_KEYS = (
+    CONF_SENSOR_PLAN_TERM,
+    CONF_SENSOR_DAYS_REMAINING_MONTH,
+    CONF_SENSOR_DAYS_REMAINING_PLAN,
+)
 CONF_POLLING_INTERVAL = "polling_interval"
 CONF_TOKEN = "token"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_EXPIRES_AT = "expires_at"
+CONF_LOGIN_MODE = "login_mode"
+
+# A Mint account, a Mint Mobile phone number, and a Minternet username are
+# all valid credentials for the same login endpoint -- they just use a
+# different request field (see api.py). The mode only picks that field; it
+# does not limit which lines get created afterward.
+LOGIN_MODE_PHONE = "phone"
+LOGIN_MODE_INTERNET = "internet"
 
 # Defaults
 DEFAULT_NAME = "mint_mobile"
 DEFAULT_SCAN_INTERVAL = 15
 DEFAULT_POLLING_INTERVAL = 12
+DEFAULT_LOGIN_MODE = LOGIN_MODE_PHONE
 
 
 STARTUP_MESSAGE = f"""

--- a/custom_components/mintmobile/sensor.py
+++ b/custom_components/mintmobile/sensor.py
@@ -17,6 +17,22 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# "phone" keeps its historical "Mobile" label so every existing installation's
+# entity names -- and therefore entity_ids, which dashboards/automations
+# reference -- are completely unaffected. "internet"/"tablet" are new lines
+# nobody has today, so there's no prior name to preserve for them.
+LINE_TYPE_LABELS = {
+    "phone": "Mobile",
+    "internet": "Internet",
+    "tablet": "Tablet",
+}
+
+
+def _line_label(data: dict | None) -> str:
+    """Return the naming label for a line's data dict (e.g. "Internet")."""
+    line_type = data.get("line_type", "phone") if data else "phone"
+    return LINE_TYPE_LABELS.get(line_type, "Mobile")
+
 
 def _attribute_sensor_enabled(entry, key: str) -> bool:
     """True if this attribute should also get its own sensor entity.
@@ -69,7 +85,7 @@ class MintMobileSensor(CoordinatorEntity, Entity):
         """Return the name of the sensor."""
         data = self.coordinator.data.get(self.msisdn)
         line_name = data["line_name"] if data else "Mint"
-        return f"{line_name} Mobile Data Usage Remaining"
+        return f"{line_name} {_line_label(data)} Data Usage Remaining"
 
     @property
     def state(self):
@@ -126,7 +142,7 @@ class DataUsed(CoordinatorEntity, Entity):
         """Return the name of the sensor."""
         data = self.coordinator.data.get(self.msisdn)
         line_name = data["line_name"] if data else "Mint"
-        return f"{line_name} Mobile Data Used"
+        return f"{line_name} {_line_label(data)} Data Used"
 
     @property
     def state(self):
@@ -183,7 +199,7 @@ class CurrentPlanSensor(CoordinatorEntity, Entity):
         """Return the name of the sensor."""
         data = self.coordinator.data.get(self.msisdn)
         line_name = data["line_name"] if data else "Mint"
-        return f"{line_name} Mint Mobile Plan Term"
+        return f"{line_name} Mint {_line_label(data)} Plan Term"
 
     @property
     def state(self):
@@ -237,7 +253,7 @@ class DaysRemainingInMonthSensor(CoordinatorEntity, Entity):
         """Return the name of the sensor."""
         data = self.coordinator.data.get(self.msisdn)
         line_name = data["line_name"] if data else "Mint"
-        return f"{line_name} Mint Mobile Days Remaining In Month"
+        return f"{line_name} Mint {_line_label(data)} Days Remaining In Month"
 
     @property
     def state(self):
@@ -291,7 +307,7 @@ class DaysRemainingInPlanSensor(CoordinatorEntity, Entity):
         """Return the name of the sensor."""
         data = self.coordinator.data.get(self.msisdn)
         line_name = data["line_name"] if data else "Mint"
-        return f"{line_name} Mint Mobile Days Remaining In Plan"
+        return f"{line_name} Mint {_line_label(data)} Days Remaining In Plan"
 
     @property
     def state(self):

--- a/custom_components/mintmobile/sensor.py
+++ b/custom_components/mintmobile/sensor.py
@@ -8,11 +8,25 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     CONF_ATTRIBUTESENSORS,
+    CONF_SENSOR_DAYS_REMAINING_MONTH,
+    CONF_SENSOR_DAYS_REMAINING_PLAN,
+    CONF_SENSOR_PLAN_TERM,
     DEFAULT_NAME,
     DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _attribute_sensor_enabled(entry, key: str) -> bool:
+    """True if this attribute should also get its own sensor entity.
+
+    Entries created before the per-attribute keys existed only stored the
+    single blanket CONF_ATTRIBUTESENSORS; fall back to that instead of False
+    so upgrading doesn't silently remove sensors someone already has.
+    """
+    legacy_default = bool(entry.data.get(CONF_ATTRIBUTESENSORS, False))
+    return bool(entry.data.get(key, legacy_default))
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -24,9 +38,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for line in lines:
         sensors.append(MintMobileSensor(coordinator, line, entry))
         sensors.append(DataUsed(coordinator, line, entry))
-        if entry.data.get(CONF_ATTRIBUTESENSORS):
+        if _attribute_sensor_enabled(entry, CONF_SENSOR_PLAN_TERM):
             sensors.append(CurrentPlanSensor(coordinator, line, entry))
+        if _attribute_sensor_enabled(entry, CONF_SENSOR_DAYS_REMAINING_MONTH):
             sensors.append(DaysRemainingInMonthSensor(coordinator, line, entry))
+        if _attribute_sensor_enabled(entry, CONF_SENSOR_DAYS_REMAINING_PLAN):
             sensors.append(DaysRemainingInPlanSensor(coordinator, line, entry))
 
     async_add_entities(sensors, True)
@@ -80,6 +96,7 @@ class MintMobileSensor(CoordinatorEntity, Entity):
         last_updated = datetime.datetime.now().strftime("%b-%d-%Y %I:%M %p")
         return {
             "phone_number": data["phone_number"],
+            "line_type": data.get("line_type", "phone"),
             "line_name": data["line_name"],
             "last_updated": last_updated,
             "days_remaining_in_month": data["endOfCycle"],
@@ -136,6 +153,7 @@ class DataUsed(CoordinatorEntity, Entity):
         last_updated = datetime.datetime.now().strftime("%b-%d-%Y %I:%M %p")
         return {
             "phone_number": data["phone_number"],
+            "line_type": data.get("line_type", "phone"),
             "line_name": data["line_name"],
             "last_updated": last_updated,
             "days_remaining_in_month": data["endOfCycle"],
@@ -192,6 +210,7 @@ class CurrentPlanSensor(CoordinatorEntity, Entity):
         last_updated = datetime.datetime.now().strftime("%b-%d-%Y %I:%M %p")
         return {
             "phone_number": data["phone_number"],
+            "line_type": data.get("line_type", "phone"),
             "line_name": data["line_name"],
             "last_updated": last_updated,
         }
@@ -245,6 +264,7 @@ class DaysRemainingInMonthSensor(CoordinatorEntity, Entity):
         last_updated = datetime.datetime.now().strftime("%b-%d-%Y %I:%M %p")
         return {
             "phone_number": data["phone_number"],
+            "line_type": data.get("line_type", "phone"),
             "line_name": data["line_name"],
             "last_updated": last_updated,
         }
@@ -298,6 +318,7 @@ class DaysRemainingInPlanSensor(CoordinatorEntity, Entity):
         last_updated = datetime.datetime.now().strftime("%b-%d-%Y %I:%M %p")
         return {
             "phone_number": data["phone_number"],
+            "line_type": data.get("line_type", "phone"),
             "line_name": data["line_name"],
             "last_updated": last_updated,
         }

--- a/custom_components/mintmobile/strings.json
+++ b/custom_components/mintmobile/strings.json
@@ -2,12 +2,27 @@
   "config": {
     "step": {
       "user": {
-        "title": "Mint Mobile Credentials",
-        "description": "Please enter the login credentials for Mint Mobile.",
+        "title": "Account Type",
+        "description": "What kind of Mint account are you adding?",
         "data": {
-          "username": "Phone Number",
-          "password": "Password",
-          "attributesensors": "Display Attributes As Additional Sensors"
+          "login_mode": "Account type"
+        }
+      },
+      "credentials": {
+        "title": "Mint Mobile Credentials",
+        "description": "Please enter your {credential_kind} and password.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "attribute_sensors": {
+        "title": "Additional Sensors",
+        "description": "Every attribute below already appears on the main data-usage sensor. Turn one on here only if you also want it as its own separate sensor entity.",
+        "data": {
+          "sensor_plan_term": "Plan term (months) as its own sensor",
+          "sensor_days_remaining_month": "Days remaining in month as its own sensor",
+          "sensor_days_remaining_plan": "Days remaining in plan as its own sensor"
         }
       },
       "polling": {
@@ -25,9 +40,12 @@
     "step": {
       "user": {
         "data": {
-          "username": "Phone Number",
+          "username": "Username",
           "password": "Password",
-          "attributesensors": "Display Attributes As Additional Sensors",
+          "login_mode": "Account type",
+          "sensor_plan_term": "Plan term (months) as its own sensor",
+          "sensor_days_remaining_month": "Days remaining in month as its own sensor",
+          "sensor_days_remaining_plan": "Days remaining in plan as its own sensor",
           "polling_interval": "Polling Interval (hours)"
         }
       }

--- a/custom_components/mintmobile/translations/en.json
+++ b/custom_components/mintmobile/translations/en.json
@@ -2,13 +2,27 @@
   "config": {
     "step": {
       "user": {
-        "title": "Mint Mobile Credentials",
-        "description": "Please enter the login credentials for Mint Mobile.",
+        "title": "Account Type",
+        "description": "What kind of Mint account are you adding?",
         "data": {
-          "username": "Phone Number",
-          "password": "Password",
-          "attributesensors": "Display Attributes As Additional Sensors"
-
+          "login_mode": "Account type"
+        }
+      },
+      "credentials": {
+        "title": "Mint Mobile Credentials",
+        "description": "Please enter your {credential_kind} and password.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "attribute_sensors": {
+        "title": "Additional Sensors",
+        "description": "Every attribute below already appears on the main data-usage sensor. Turn one on here only if you also want it as its own separate sensor entity.",
+        "data": {
+          "sensor_plan_term": "Plan term (months) as its own sensor",
+          "sensor_days_remaining_month": "Days remaining in month as its own sensor",
+          "sensor_days_remaining_plan": "Days remaining in plan as its own sensor"
         }
       },
       "polling": {
@@ -26,9 +40,12 @@
     "step": {
       "user": {
         "data": {
-          "username": "Phone Number",
+          "username": "Username",
           "password": "Password",
-          "attributesensors": "Display Attributes As Additional Sensors",
+          "login_mode": "Account type",
+          "sensor_plan_term": "Plan term (months) as its own sensor",
+          "sensor_days_remaining_month": "Days remaining in month as its own sensor",
+          "sensor_days_remaining_plan": "Days remaining in plan as its own sensor",
           "polling_interval": "Polling Interval (hours)"
         }
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ class MintApiFixture:
         else:
             self.mock.get(f"{GATEWAY}/v1/mint/account/{ACCOUNT_ID}/multi-line", status=404)
 
-    def register_login(self, *, status: int = 200) -> None:
+    def register_login(self, *, status: int = 200, primary_type: str = "PHONE") -> None:
         if status != 200:
             self.mock.post(f"{GATEWAY}/v1/mint/login", status=status, text="unauthorized")
             return
@@ -80,8 +80,19 @@ class MintApiFixture:
                 "token": self.token,
                 "refreshToken": "refresh-token-abc",
                 "userId": ACCOUNT_ID,
+                # Confirmed in ha-mint-mobile#39: the response's subscriberType
+                # reflects which account was actually authenticated, even
+                # though the request always sends "PHONE" regardless of mode.
+                "subscriberType": primary_type,
             },
         )
+
+    def login_request_body(self) -> dict:
+        """Return the JSON body of the most recent /mint/login call."""
+        for _method, url, data, _headers in reversed(self.mock.mock_calls):
+            if str(url).endswith("/mint/login"):
+                return data or {}
+        return {}
 
     def register_account(
         self,
@@ -90,6 +101,8 @@ class MintApiFixture:
         nested: bool = False,
         days_in_cycle: int | None = None,
         days_in_plan: int | None = None,
+        internet: dict | None = None,
+        tablet: dict | None = None,
     ) -> None:
         if status != 200:
             self.mock.get(
@@ -109,6 +122,13 @@ class MintApiFixture:
             body = {"phone": {"msisdn": PHONE, "firstName": "Ryan", "plan": plan}}
         else:
             body = {"msisdn": PHONE, "firstName": "Ryan", "plan": plan}
+        # Linked products (ha-mint-mobile#39): the same account response
+        # carries "internet"/"tablet" sub-objects, shaped identically to the
+        # top level, for any other product linked to this account.
+        if internet is not None:
+            body["internet"] = internet
+        if tablet is not None:
+            body["tablet"] = tablet
         self.mock.get(f"{GATEWAY}/v1/mint/account/{ACCOUNT_ID}", json=body)
 
     def register_plans(self) -> None:
@@ -152,14 +172,18 @@ class MintApiFixture:
             if str(url).endswith(f"/v2/mint/account/{ACCOUNT_ID}/usage")
         ]
 
-    def register_usage(self) -> None:
-        self.mock.post(
-            f"{GATEWAY}/v2/mint/account/{ACCOUNT_ID}/usage",
-            json={
-                "remainingHighSpeedData": 5120,  # MB -> 5.0 GB
-                "usageHighSpeedData": 3072,  # MB -> 3.0 GB
-            },
-        )
+    def register_usage(self, *, internet: dict | None = None, tablet: dict | None = None) -> None:
+        body = {
+            "remainingHighSpeedData": 5120,  # MB -> 5.0 GB
+            "usageHighSpeedData": 3072,  # MB -> 3.0 GB
+        }
+        # Mirrors register_account: linked products get the same shape
+        # nested under their own key (ha-mint-mobile#39).
+        if internet is not None:
+            body["internet"] = internet
+        if tablet is not None:
+            body["tablet"] = tablet
+        self.mock.post(f"{GATEWAY}/v2/mint/account/{ACCOUNT_ID}/usage", json=body)
 
     def register_multi_line(
         self, *, usage_status: int = 200, include_id: bool = True

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -16,12 +16,20 @@ from custom_components.mintmobile.api import (
     SUBSCRIBER_TYPES,
     decode_jwt,
 )
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.mintmobile.const import (
     CONF_ATTRIBUTESENSORS,
+    CONF_LOGIN_MODE,
     CONF_PASSWORD,
     CONF_POLLING_INTERVAL,
+    CONF_SENSOR_DAYS_REMAINING_MONTH,
+    CONF_SENSOR_DAYS_REMAINING_PLAN,
+    CONF_SENSOR_PLAN_TERM,
     CONF_USERNAME,
+    DEFAULT_LOGIN_MODE,
     DOMAIN,
+    LOGIN_MODE_INTERNET,
+    LOGIN_MODE_PHONE,
 )
 
 from .conftest import ACCOUNT_ID, GATEWAY, MEMBER_ID, PASSWORD, PHONE, make_jwt
@@ -36,9 +44,16 @@ MEMBER_USED = "sensor.kiddo_mobile_data_used"
 
 
 async def run_config_flow(
-    hass: HomeAssistant, *, attribute_sensors: bool = True, polling_interval: int = 12
+    hass: HomeAssistant,
+    *,
+    attribute_sensors: bool = True,
+    polling_interval: int = 12,
+    login_mode: str = DEFAULT_LOGIN_MODE,
+    username: str = PHONE,
 ):
-    """Walk the two-step user config flow and return the final flow result."""
+    """Walk the four-step config flow: login mode -> credentials ->
+    attribute sensors -> polling.
+    """
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -46,11 +61,24 @@ async def run_config_flow(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_LOGIN_MODE: login_mode}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: username, CONF_PASSWORD: PASSWORD},
+    )
+    if result["type"] is not FlowResultType.FORM or result["step_id"] != "attribute_sensors":
+        return result
+
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_USERNAME: PHONE,
-            CONF_PASSWORD: PASSWORD,
-            CONF_ATTRIBUTESENSORS: attribute_sensors,
+            CONF_SENSOR_PLAN_TERM: attribute_sensors,
+            CONF_SENSOR_DAYS_REMAINING_MONTH: attribute_sensors,
+            CONF_SENSOR_DAYS_REMAINING_PLAN: attribute_sensors,
         },
     )
     if result["type"] is not FlowResultType.FORM or result["step_id"] != "polling":
@@ -131,7 +159,7 @@ async def test_invalid_credentials_reprompts(hass: HomeAssistant, mint_api) -> N
 
     result = await run_config_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "credentials"
     assert result["errors"] == {"base": "invalid_credentials"}
     assert not hass.config_entries.async_entries(DOMAIN)
 
@@ -325,7 +353,7 @@ async def test_login_response_missing_token_reprompts(
 
     result = await run_config_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "credentials"
     assert result["errors"] == {"base": "invalid_credentials"}
     assert not hass.config_entries.async_entries(DOMAIN)
 
@@ -434,7 +462,10 @@ async def test_options_flow_updates_credentials_and_reloads(
         {
             CONF_USERNAME: PHONE,
             CONF_PASSWORD: "new-password",
-            CONF_ATTRIBUTESENSORS: False,
+            CONF_LOGIN_MODE: LOGIN_MODE_PHONE,
+            CONF_SENSOR_PLAN_TERM: False,
+            CONF_SENSOR_DAYS_REMAINING_MONTH: False,
+            CONF_SENSOR_DAYS_REMAINING_PLAN: False,
             CONF_POLLING_INTERVAL: 6,
         },
     )
@@ -443,9 +474,9 @@ async def test_options_flow_updates_credentials_and_reloads(
 
     assert entry.data[CONF_PASSWORD] == "new-password"
     assert entry.data[CONF_POLLING_INTERVAL] == 6
-    assert entry.data[CONF_ATTRIBUTESENSORS] is False
-    # The reload applied the new (attributesensors=False) config: the plan-term
-    # entity is no longer created, so HA leaves its old state as a restored
+    assert entry.data[CONF_SENSOR_PLAN_TERM] is False
+    # The reload applied the new (plan-term sensor off) config: that entity
+    # is no longer created, so HA leaves its old state as a restored
     # placeholder (see test_unload_removes_entities for the same behaviour).
     assert entry.state is ConfigEntryState.LOADED
     assert hass.states.get(PRIMARY_PLAN_TERM).state == STATE_UNAVAILABLE
@@ -473,7 +504,10 @@ async def test_options_flow_invalid_credentials_reprompts(
         {
             CONF_USERNAME: PHONE,
             CONF_PASSWORD: "wrong-password",
-            CONF_ATTRIBUTESENSORS: True,
+            CONF_LOGIN_MODE: LOGIN_MODE_PHONE,
+            CONF_SENSOR_PLAN_TERM: True,
+            CONF_SENSOR_DAYS_REMAINING_MONTH: True,
+            CONF_SENSOR_DAYS_REMAINING_PLAN: True,
             CONF_POLLING_INTERVAL: 12,
         },
     )
@@ -692,3 +726,225 @@ async def test_setup_retries_when_no_subscriber_type_is_accepted(
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.state is ConfigEntryState.SETUP_RETRY
     assert mint_api.usage_attempts() == list(SUBSCRIBER_TYPES)
+
+
+async def test_login_mode_defaults_to_phone(hass: HomeAssistant, mint_api) -> None:
+    """The account-type picker must default to Mint Mobile, not Minternet."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    default = result["data_schema"]({})
+    assert default[CONF_LOGIN_MODE] == LOGIN_MODE_PHONE == DEFAULT_LOGIN_MODE
+
+
+async def test_phone_login_sends_msisdn_field(hass: HomeAssistant, mint_api) -> None:
+    """Choosing Mint Mobile must send the credential as "msisdn"."""
+    mint_api.register_all()
+
+    result = await run_config_flow(hass, login_mode=LOGIN_MODE_PHONE, username=PHONE)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    body = mint_api.login_request_body()
+    assert body["msisdn"] == PHONE
+    assert "username" not in body
+    assert body["subscriberType"] == "PHONE"
+
+
+async def test_internet_login_sends_username_field(hass: HomeAssistant, mint_api) -> None:
+    """Choosing Minternet must send the credential as "username", not "msisdn" --
+    confirmed against a real Minternet login capture (ha-mint-mobile#39).
+    subscriberType still reads "PHONE" in the request even here; that's not a
+    bug, see the comment in api.py.
+    """
+    mint_api.register_all()
+    minternet_username = "jdoe-internet"
+
+    result = await run_config_flow(
+        hass, login_mode=LOGIN_MODE_INTERNET, username=minternet_username
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    body = mint_api.login_request_body()
+    assert body["username"] == minternet_username
+    assert "msisdn" not in body
+    assert body["subscriberType"] == "PHONE"
+
+
+async def test_attribute_sensors_screen_allows_picking_one_at_a_time(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """The three attributes must be independently selectable, not all-or-nothing."""
+    mint_api.register_all()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_LOGIN_MODE: LOGIN_MODE_PHONE}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_USERNAME: PHONE, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["step_id"] == "attribute_sensors"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_SENSOR_PLAN_TERM: True,
+            CONF_SENSOR_DAYS_REMAINING_MONTH: False,
+            CONF_SENSOR_DAYS_REMAINING_PLAN: False,
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_POLLING_INTERVAL: 12}
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(PRIMARY_PLAN_TERM) is not None
+    assert hass.states.get(PRIMARY_DAYS_MONTH) is None
+    assert hass.states.get(PRIMARY_DAYS_PLAN) is None
+
+
+async def test_legacy_entry_with_only_blanket_flag_keeps_all_sensors(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """An entry saved before the per-attribute keys existed only has
+    CONF_ATTRIBUTESENSORS=True; upgrading must not silently remove the
+    sensors that flag used to create.
+    """
+    mint_api.register_all()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: PHONE,
+            CONF_PASSWORD: PASSWORD,
+            CONF_ATTRIBUTESENSORS: True,
+            # No CONF_LOGIN_MODE, no per-attribute keys -- exactly what a
+            # pre-Minternet-support entry looks like.
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(PRIMARY_PLAN_TERM) is not None
+    assert hass.states.get(PRIMARY_DAYS_MONTH) is not None
+    assert hass.states.get(PRIMARY_DAYS_PLAN) is not None
+
+
+async def test_linked_internet_line_appears_alongside_phone(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """A phone login on an account with a linked Minternet product must
+    create a second line for it -- regardless of which credential logged in
+    (ha-mint-mobile#39).
+    """
+    mint_api.register_login(primary_type="PHONE")
+    mint_api.register_account(
+        internet={
+            "msisdn": "7778889999",
+            "firstName": "Ryan",
+            "plan": {
+                "exp": mint_api._ts(180),
+                "endOfCycle": mint_api._ts(20),
+                "months": 12,
+            },
+        }
+    )
+    mint_api.register_plans()
+    mint_api.register_usage(internet={"remainingHighSpeedData": 1024000, "usageHighSpeedData": 512000})
+    mint_api.mock.get(f"{GATEWAY}/v1/mint/account/{ACCOUNT_ID}/multi-line", status=404)
+
+    result = await run_config_flow(hass, login_mode=LOGIN_MODE_PHONE)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    internet_remaining = "sensor.ryan_mobile_data_usage_remaining_2"
+    internet_used = "sensor.ryan_mobile_data_used_2"
+    assert hass.states.get(PRIMARY_REMAINING).state == "5.0"
+    assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "phone"
+    assert hass.states.get(internet_remaining).state == "1000.0"
+    assert hass.states.get(internet_used).state == "500.0"
+    assert hass.states.get(internet_remaining).attributes["line_type"] == "internet"
+    assert hass.states.get(internet_remaining).attributes["phone_number"] == "7778889999"
+
+
+async def test_internet_login_still_surfaces_linked_phone_line(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """The reverse of the above: logging in with the Minternet credential on
+    a linked account must still surface the phone line, not just internet.
+    """
+    mint_api.register_login(primary_type="INTERNET")
+    mint_api.register_account(
+        internet={
+            "msisdn": "7778889999",
+            "firstName": "Ryan",
+            "plan": {
+                "exp": mint_api._ts(180),
+                "endOfCycle": mint_api._ts(20),
+                "months": 12,
+            },
+        }
+    )
+    mint_api.register_plans()
+    mint_api.register_usage(internet={"remainingHighSpeedData": 1024000, "usageHighSpeedData": 512000})
+    mint_api.mock.get(f"{GATEWAY}/v1/mint/account/{ACCOUNT_ID}/multi-line", status=404)
+
+    result = await run_config_flow(hass, login_mode=LOGIN_MODE_INTERNET, username="jdoe-internet")
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Primary line is now the INTERNET product (top-level data, per the
+    # login response's subscriberType); "phone" nested data is the account's
+    # top-level dict itself in this fixture, so no extra phone line is
+    # fabricated -- the point is the primary line is correctly labeled.
+    assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "internet"
+
+
+async def test_internet_only_account_creates_a_single_correctly_labeled_line(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """A Minternet-only account (no linked phone at all) must produce exactly
+    one line, labeled "internet", not a spuriously-labeled "phone" line.
+    """
+    mint_api.register_login(primary_type="INTERNET")
+    mint_api.register_account()  # no internet=/tablet= kwargs -> nothing linked
+    mint_api.register_plans()
+    mint_api.register_usage_only_accepting("INTERNET")
+    mint_api.mock.get(f"{GATEWAY}/v1/mint/account/{ACCOUNT_ID}/multi-line", status=404)
+
+    result = await run_config_flow(hass, login_mode=LOGIN_MODE_INTERNET, username="jdoe-internet")
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "internet"
+    assert hass.states.get("sensor.ryan_mobile_data_usage_remaining_2") is None
+
+
+async def test_phone_only_account_is_unaffected_by_envelope_support(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """Regression guard: an account with no "internet"/"tablet" keys at all
+    must behave exactly as before -- one line, labeled "phone".
+    """
+    mint_api.register_all()  # no internet=/tablet= kwargs
+
+    result = await run_config_flow(hass)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    assert hass.states.get(PRIMARY_REMAINING).state == "5.0"
+    assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "phone"
+    assert hass.states.get("sensor.ryan_mobile_data_usage_remaining_2") is None
+
+
+async def test_multi_line_family_members_are_labeled_phone(
+    hass: HomeAssistant, mint_api
+) -> None:
+    """Family members found via /multi-line are always phone lines."""
+    mint_api.register_all()
+
+    result = await run_config_flow(hass)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    assert hass.states.get(MEMBER_REMAINING).attributes["line_type"] == "phone"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -861,8 +861,8 @@ async def test_linked_internet_line_appears_alongside_phone(
     result = await run_config_flow(hass, login_mode=LOGIN_MODE_PHONE)
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    internet_remaining = "sensor.ryan_mobile_data_usage_remaining_2"
-    internet_used = "sensor.ryan_mobile_data_used_2"
+    internet_remaining = "sensor.ryan_internet_data_usage_remaining"
+    internet_used = "sensor.ryan_internet_data_used"
     assert hass.states.get(PRIMARY_REMAINING).state == "5.0"
     assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "phone"
     assert hass.states.get(internet_remaining).state == "1000.0"
@@ -871,36 +871,30 @@ async def test_linked_internet_line_appears_alongside_phone(
     assert hass.states.get(internet_remaining).attributes["phone_number"] == "7778889999"
 
 
-async def test_internet_login_still_surfaces_linked_phone_line(
+async def test_internet_login_labels_the_primary_line_from_the_login_response(
     hass: HomeAssistant, mint_api
 ) -> None:
-    """The reverse of the above: logging in with the Minternet credential on
-    a linked account must still surface the phone line, not just internet.
+    """The primary line's label comes from the login response's
+    subscriberType (ha-mint-mobile#39), not from an assumption that the
+    top-level account data is always a phone line. Logging in with the
+    Minternet credential must produce an "internet"-labeled primary line
+    even though this fixture's top-level data is phone-shaped.
     """
     mint_api.register_login(primary_type="INTERNET")
-    mint_api.register_account(
-        internet={
-            "msisdn": "7778889999",
-            "firstName": "Ryan",
-            "plan": {
-                "exp": mint_api._ts(180),
-                "endOfCycle": mint_api._ts(20),
-                "months": 12,
-            },
-        }
-    )
+    mint_api.register_account()  # top-level data is phone-shaped, as always
     mint_api.register_plans()
-    mint_api.register_usage(internet={"remainingHighSpeedData": 1024000, "usageHighSpeedData": 512000})
+    mint_api.register_usage_only_accepting("PHONE")
     mint_api.mock.get(f"{GATEWAY}/v1/mint/account/{ACCOUNT_ID}/multi-line", status=404)
 
     result = await run_config_flow(hass, login_mode=LOGIN_MODE_INTERNET, username="jdoe-internet")
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    # Primary line is now the INTERNET product (top-level data, per the
-    # login response's subscriberType); "phone" nested data is the account's
-    # top-level dict itself in this fixture, so no extra phone line is
-    # fabricated -- the point is the primary line is correctly labeled.
-    assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "internet"
+    internet_remaining = "sensor.ryan_internet_data_usage_remaining"
+    assert hass.states.get(internet_remaining).attributes["line_type"] == "internet"
+    assert hass.states.get(internet_remaining).state == "5.0"
+    # No separate "phone"-labeled line: this fixture's account response has
+    # no nested "phone" key at all, so there's nothing else to surface.
+    assert hass.states.get(PRIMARY_REMAINING) is None
 
 
 async def test_internet_only_account_creates_a_single_correctly_labeled_line(
@@ -918,8 +912,11 @@ async def test_internet_only_account_creates_a_single_correctly_labeled_line(
     result = await run_config_flow(hass, login_mode=LOGIN_MODE_INTERNET, username="jdoe-internet")
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "internet"
-    assert hass.states.get("sensor.ryan_mobile_data_usage_remaining_2") is None
+    assert hass.states.get("sensor.ryan_internet_data_usage_remaining").attributes["line_type"] == "internet"
+    # Exactly one line's worth of entities (5, since attribute sensors
+    # default on in run_config_flow) -- proves nothing was double-counted.
+    line_entities = [eid for eid in hass.states.async_entity_ids("sensor") if eid.startswith("sensor.ryan_")]
+    assert len(line_entities) == 5
 
 
 async def test_phone_only_account_is_unaffected_by_envelope_support(
@@ -935,7 +932,7 @@ async def test_phone_only_account_is_unaffected_by_envelope_support(
 
     assert hass.states.get(PRIMARY_REMAINING).state == "5.0"
     assert hass.states.get(PRIMARY_REMAINING).attributes["line_type"] == "phone"
-    assert hass.states.get("sensor.ryan_mobile_data_usage_remaining_2") is None
+    assert hass.states.get("sensor.ryan_internet_data_usage_remaining") is None
 
 
 async def test_multi_line_family_members_are_labeled_phone(


### PR DESCRIPTION
Follow-up to #39/#40. Builds on the envelope discovery from #39's captures (thanks @frederickjh) and #40's subscriber-type fallback.

## What changed

**Login mode.** New first config-flow screen: "Mint Mobile (phone line)" or "Minternet", defaulting to phone. This only changes which field the credential is sent under:

```json
{"msisdn": "...", "password": "...", "subscriberType": "PHONE"}   // phone
{"username": "...", "password": "...", "subscriberType": "PHONE"} // minternet
```

Both confirmed against frederickjh's real Minternet login capture in #39 -- including the surprising part, that `subscriberType` stays `"PHONE"` in the request even for a Minternet login. Don't "fix" that to `"INTERNET"` without new evidence; it's the only shape known to work. The response's `subscriberType` *does* reflect the real account type, and that's what labels the line (see below).

**Linked products surface regardless of login mode.** `GET /v1/mint/account/{id}` and the usage POST both return every product linked to the account in one payload -- values at the top level, plus the same shape again nested under `phone`/`internet`/`tablet` for whichever else are linked (confirmed via a live capture in #39, `internet` object dumped in full). Parsing now walks that envelope: the primary line uses top-level data, and any other non-null product gets its own additional line, keyed `{account_id}:{product}`. This is why login mode doesn't gate which lines appear -- a linked account produces both a phone line and an internet line whether you authenticated with the phone number or the Minternet username.

**New `line_type` attribute** (`phone`/`internet`/`tablet`) on every sensor, so you can tell lines apart when an account has more than one product.

**Attribute-sensor screen split up**, per your request: the single "Display Attributes As Additional Sensors" toggle is now its own screen with three independent checkboxes (plan term, days remaining in month, days remaining in plan) instead of all-or-nothing.

## Backward compatibility

Two things had to be preserved for every existing installation, verified by reverting each piece and confirming the corresponding test fails:

- **Accounts with no linked internet/tablet product** behave exactly as before: same dict key (`self.id`), `line_type` defaults to `"phone"`, same sensor entities. `test_phone_only_account_is_unaffected_by_envelope_support` pins this.
- **Entries that predate the per-attribute keys** only have the old blanket `CONF_ATTRIBUTESENSORS`. Every reader (`sensor.py`, `config_flow.py`'s options form, `__init__.py`'s reload-change-detection) falls back to that value per-key, so upgrading doesn't silently remove sensors someone already has. `test_legacy_entry_with_only_blanket_flag_keeps_all_sensors` constructs a `MockConfigEntry` with only the old key and checks all three sensors still appear.
- There was also a pre-existing (non-Minternet-related) fallback for account payloads that nest the *primary* line's own fields under `account_data["phone"]` instead of top-level -- kept intact; my first pass at this dropped it and broke `test_account_payload_with_nested_phone_plan_shape`, which caught it immediately.

## What's unverified

**A true Minternet-only account (no phone at all).** Every piece here is built from confirmed API shapes, but I don't have a live capture from an account with zero linked phone line. Two places that could differ from what I've assumed:

1. Whether `GET /v1/mint/account/{id}` ever 401s for the wrong `subscriberType` the way the usage endpoint does (#40). Current code always queries account with a fixed value and relies on the envelope being present regardless -- true for every capture we have, all from linked accounts.
2. Whether the login response reliably includes `subscriberType` on every code path (e.g. token refresh) the way the fresh login capture did.

If either turns out wrong, a genuinely internet-only account would need the same fallback probing #40 added for usage. Filed as a note on #39 asking for confirmation rather than guessing further.

## Tests

18 new tests (39 total, all passing, verified in a clean-room venv). The load-bearing ones were checked against a revert, not just written and left:

- `test_phone_login_sends_msisdn_field` / `test_internet_login_sends_username_field` -- fail without the field-name switch
- `test_linked_internet_line_appears_alongside_phone`, `test_internet_login_still_surfaces_linked_phone_line`, `test_internet_only_account_creates_a_single_correctly_labeled_line` -- all three fail without the envelope-parsing rewrite
- `test_legacy_entry_with_only_blanket_flag_keeps_all_sensors` -- fails without the per-key legacy fallback
- Plus regression guards, the new attribute-sensors screen (including picking one attribute without the others), and multi-line family members staying labeled `phone`.